### PR TITLE
Add fast caching support for Linux and MacOS + npm

### DIFF
--- a/basic-esy-project-with-caching/azure-pipelines.yml
+++ b/basic-esy-project-with-caching/azure-pipelines.yml
@@ -11,14 +11,17 @@ jobs:
     vmImage: 'Ubuntu 16.04'
 
   variables:
-    ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i/
-    ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source-tarballs
+    STAGING_DIRECTORY: /home/vsts/STAGING
+    STAGING_DIRECTORY_UNIX: /home/vsts/STAGING
+    ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
+    ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
+    # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
 
   steps:
-  # TODO: Uncomment this when you have a green build, to enable caching
-  # - template: restore-build-cache.yml
-  - template: esy-build-steps.yml
-  # - template: publish-build-cache.yml
+  - template: .ci/use-node.yml
+  - template: .ci/restore-build-cache.yml
+  - template: .ci/esy-build-steps.yml
+  - template: .ci/publish-build-cache.yml
 
 - job: MacOS
   timeoutInMinutes: 0
@@ -26,14 +29,17 @@ jobs:
     vmImage: 'macOS 10.13'
 
   variables:
-    ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i/
-    ESY__CACHE_SOURCE_TARBALL_PATH: /Users/vsts/.esy/source-tarballs
+    STAGING_DIRECTORY: /Users/vsts/STAGING
+    STAGING_DIRECTORY_UNIX: /Users/vsts/STAGING
+    ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i
+    ESY__CACHE_SOURCE_TARBALL_PATH: /Users/vsts/.esy/source/i
+    # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
 
   steps:
-  # TODO: Uncomment this when you have a green build, to enable caching
-  # - template: restore-build-cache.yml
-  - template: esy-build-steps.yml
-  # - template: publish-build-cache.yml
+  - template: .ci/use-node.yml
+  - template: .ci/restore-build-cache.yml
+  - template: .ci/esy-build-steps.yml
+  - template: .ci/publish-build-cache.yml
 
 - job: Windows
   timeoutInMinutes: 0
@@ -41,27 +47,31 @@ jobs:
     vmImage: 'vs2017-win2016'
 
   variables:
-    ESY__CACHE_INSTALL_PATH: C:\Users\VssAdministrator\.esy\3_\i
-    ESY__CACHE_SOURCE_TARBALL_PATH: C:\Users\VssAdministrator\.esy\source-tarballs
+    STAGING_DIRECTORY: C:\Users\VssAdministrator\STAGING
+    STAGING_DIRECTORY_UNIX: /C/Users/VssAdministrator/STAGING
+    ESY__CACHE_INSTALL_PATH: /C/Users/VssAdministrator/.esy/3_/i
+    ESY__CACHE_SOURCE_TARBALL_PATH: /C/Users/VssAdministrator/.esy/source/i
+    # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
 
   steps:
-  - template: restore-build-cache.yml
-  - template: esy-build-steps.yml
-  - template: publish-build-cache.yml
+  - template: .ci/use-node.yml
+  - template: .ci/restore-build-cache.yml
+  - template: .ci/esy-build-steps.yml
+  - template: .ci/publish-build-cache.yml
 
-- job: Release
-  timeoutInMinutes: 0
-  displayName: Release
-  dependsOn:
-      - Linux
-      - MacOS
-      - Windows
-  condition: succeeded()
-  pool:
-     vmImage: ubuntu-16.04
-  steps:
-    - task: PublishBuildArtifacts@1
-      displayName: 'Release Package'
-      inputs:
-          PathtoPublish: '.'
-          ArtifactName: npm-package
+# - job: Release
+#   timeoutInMinutes: 0
+#   displayName: Release
+#   dependsOn:
+#       - Linux
+#       - MacOS
+#       - Windows
+#   condition: succeeded()
+#   pool:
+#      vmImage: ubuntu-16.04
+#   steps:
+#     - task: PublishBuildArtifacts@1
+#       displayName: 'Release Package'
+#       inputs:
+#           PathtoPublish: '.'
+#           ArtifactName: npm-package

--- a/basic-esy-project-with-caching/azure-pipelines.yml
+++ b/basic-esy-project-with-caching/azure-pipelines.yml
@@ -59,19 +59,19 @@ jobs:
   - template: .ci/esy-build-steps.yml
   - template: .ci/publish-build-cache.yml
 
-# - job: Release
-#   timeoutInMinutes: 0
-#   displayName: Release
-#   dependsOn:
-#       - Linux
-#       - MacOS
-#       - Windows
-#   condition: succeeded()
-#   pool:
-#      vmImage: ubuntu-16.04
-#   steps:
-#     - task: PublishBuildArtifacts@1
-#       displayName: 'Release Package'
-#       inputs:
-#           PathtoPublish: '.'
-#           ArtifactName: npm-package
+- job: Release
+  timeoutInMinutes: 0
+  displayName: Release
+  dependsOn:
+      - Linux
+      - MacOS
+      - Windows
+  condition: succeeded()
+  pool:
+     vmImage: ubuntu-16.04
+  steps:
+    - task: PublishBuildArtifacts@1
+      displayName: 'Release Package'
+      inputs:
+          PathtoPublish: '.'
+          ArtifactName: npm-package

--- a/basic-esy-project-with-caching/esy-build-steps.yml
+++ b/basic-esy-project-with-caching/esy-build-steps.yml
@@ -1,9 +1,6 @@
 # Cross-platform set of build steps for building esy projects
 
 steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '8.9'
   - script: npm install -g esy@0.4.3
     displayName: 'npm install -g esy@0.4.3'
   - script: esy install

--- a/basic-esy-project-with-caching/publish-build-cache.yml
+++ b/basic-esy-project-with-caching/publish-build-cache.yml
@@ -1,11 +1,24 @@
 # Steps for publishing project cache
 
 steps:
+  - bash: 'mkdir -p $(STAGING_DIRECTORY_UNIX)'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Publish] Create cache directory'
+
+  - bash: 'cd $(ESY__CACHE_INSTALL_PATH) && tar -czf $(STAGING_DIRECTORY_UNIX)/esy-cache.tar .'
+    workingDirectory: ''
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Publish] Tar esy cache directory'
+
+  # - bash: 'cd $(ESY__NPM_ROOT) && tar -czf $(STAGING_DIRECTORY_UNIX)/npm-cache.tar .'
+  #   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #   displayName: '[Cache][Publish] Tar npm cache directory'
+
   - task: PublishBuildArtifacts@1
-    displayName: 'Cache: Upload install folder'
+    displayName: '[Cache][Publish] Upload tarball'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
-        pathToPublish: '$(ESY__CACHE_INSTALL_PATH)'
+        pathToPublish: '$(STAGING_DIRECTORY)'
         artifactName: 'cache-$(Agent.OS)-install'
         parallel: true
         parallelCount: 8

--- a/basic-esy-project-with-caching/restore-build-cache.yml
+++ b/basic-esy-project-with-caching/restore-build-cache.yml
@@ -3,7 +3,7 @@
 steps:
   - task: DownloadBuildArtifacts@0
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
-    displayName: 'Cache: Restore install'
+    displayName: '[Cache][Restore] Restore install'
     inputs:
         buildType: 'specific'
         project: '$(System.TeamProject)'
@@ -12,12 +12,25 @@ steps:
         buildVersionToDownload: 'latestFromBranch'
         downloadType: 'single'
         artifactName: 'cache-$(Agent.OS)-install'
-        downloadPath: '$(System.ArtifactsDirectory)'
+        downloadPath: '$(STAGING_DIRECTORY)'
     continueOnError: true
 
-  - task: CopyFiles@2
+  - bash: 'mkdir -p $(ESY__CACHE_INSTALL_PATH)'
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
-    inputs:
-        sourceFolder: '$(System.ArtifactsDirectory)\cache-$(Agent.OS)-install'
-        targetFolder: '$(ESY__CACHE_INSTALL_PATH)'
+    displayName: '[Cache][Restore] Create cache directory'
+
+  # - bash: 'cd $(ESY__NPM_ROOT) && tar -xf $(STAGING_DIRECTORY_UNIX)/cache-$(Agent.OS)-install/npm-cache.tar -C .'
+  #   continueOnError: true
+  #   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #   displayName: '[Cache][Restore] Untar npm cache directory'
+
+  - bash: 'cd $(ESY__CACHE_INSTALL_PATH) && tar -xf $(STAGING_DIRECTORY_UNIX)/cache-$(Agent.OS)-install/esy-cache.tar -C .'
     continueOnError: true
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Restore] Untar esy cache directory'
+
+  - bash: 'rm -rf *'
+    continueOnError: true
+    workingDirectory: '$(STAGING_DIRECTORY)'
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Restore] Clean up'

--- a/basic-esy-project-with-caching/use-node.yml
+++ b/basic-esy-project-with-caching/use-node.yml
@@ -1,0 +1,5 @@
+steps:
+  - task: NodeTool@0
+    displayName: 'Use Node 8.x'
+    inputs:
+      versionSpec: 8.x


### PR DESCRIPTION
This PR adds fast caching support for Linux and MacOS + adds (commented out) support for npm caching.

**Why was caching slow on MacOS/Linux before?**
Azure Pipelines artifact uploader is really bad at uploading a ton of small files on Linux/MacOS. Thus the main purpose of this PR is to add an extra step to tarball the entire cached folder first so Azure only uploads one file

**Why is NPM caching commented out?**
NPM caching is commented out because in my experience it actually takes longer to untar the package than it does to simply install it, but I have left it here in case someone has a good use for it. 

**Why does it use a custom staging directory?**
One of the notable changes this PR makes is that it creates a custom build staging directory in order to play nice with git bash when building on windows (Azure `BuildArtifactStaging` path is only provided in Windows C:\ format which is incompatible with bash commands)

**Why does it use the `tar` command?**
It also uses the `tar` command instead of using the `ArchiveFiles` task as I found `ArchiveFiles` buggy when detecting what to archive from the esy cache. 

Sample build (with windows disabled) https://kpsuperplane.visualstudio.com/Test%20Project/_build/results?buildId=97&view=logs 